### PR TITLE
Add a ReadonlySpan<T> comparison and use BenchmarkDotNet for measurement

### DIFF
--- a/MemoryComparison/MemoryComparison.csproj
+++ b/MemoryComparison/MemoryComparison.csproj
@@ -22,4 +22,8 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.11.3" />
+  </ItemGroup>
+
 </Project>

--- a/MemoryComparison/SpanComparison.cs
+++ b/MemoryComparison/SpanComparison.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace MemoryComparison
+{
+    public class SpanComparison : IComparison
+    {
+        public unsafe bool Compare(byte[] A, byte[] B)
+        {
+            var a = new ReadOnlySpan<byte>(A);
+            var b = new ReadOnlySpan<byte>(B);
+            return a.SequenceEqual(b);
+        }
+    }
+}


### PR DESCRIPTION
This adds a comparison using ReadOnlySpan<byte> that outperforms the memcmp version. It also replaces the hand built measurement code with BenchmarkDotNet.